### PR TITLE
Update footer information

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,7 @@ timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 include:
   - _pages
+  - social-share
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
@@ -110,9 +111,10 @@ author:
 footer:
   links:
     - label: "Peer Tutoring Center Homepage"
+      icon: "far fa-window-restore"
       url: "https://ncvps.org/peer-tutoring-center/"
     - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
+      icon: "fab fa-instagram"
       url: "https://www.instagram.com/ncvps_ptc/"
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"
@@ -120,6 +122,7 @@ footer:
     - label: "Facebook"
       icon: "fab fa-fw fa-facebook-square"
       url: https://www.facebook.com/NCVPSPTC/
+
 
 defaults:
   # _posts

--- a/_config.yml
+++ b/_config.yml
@@ -122,7 +122,9 @@ footer:
     - label: "Facebook"
       icon: "fab fa-fw fa-facebook-square"
       url: https://www.facebook.com/NCVPSPTC/
-
+    - label: "Statuspage"
+      icon: "fas fa-check-square"
+      url: https://ptcresourcespage.statuspage.io/
 
 defaults:
   # _posts

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
 layout: home
 author_profile: false
 ---
+
+
 <h1>Welcome to the Peer Tutoring Center Resource page</h1>
 <a href="/resources" class="btn btn--inverse btn--large">Resources Page</a>
 <a href="/posts" class="btn btn--inverse btn--large">Peer Tutoring Center News</a>


### PR DESCRIPTION
The following changes were made to the footer:

- Link (with icon) to the ptcresources.github.io Statuspage added.
![Screenshot 2020-12-31 133330](https://user-images.githubusercontent.com/39242954/103421910-d52d5080-4b6c-11eb-871c-418248169792.png)
- Peer Tutoring Center Homepage icon updated.
![Screenshot 2020-12-31 133339](https://user-images.githubusercontent.com/39242954/103421914-d8284100-4b6c-11eb-9096-211e896634c7.png)
