### PR TITLE
Add 'Additional Resources' button to AP Biology

### DIFF
--- a/_pages/resources/ap_biology.md
+++ b/_pages/resources/ap_biology.md
@@ -11,4 +11,8 @@ toc_label: " Table of Contents"
 toc_icon: "file-alt"
 ---
 
-# Coming Soon
+# Course Material
+<a href="https://docs.google.com/document/d/13p_tOECzoVcDrUoLHtF1wgczsYc4I7CUUe6f99DiZfc/edit?usp=sharing" class="btn btn--inverse btn--x-large">Additional Resources</a>
+
+# Units
+Coming Soon

--- a/_pages/resources/biology_honors.md
+++ b/_pages/resources/biology_honors.md
@@ -18,7 +18,7 @@ toc_icon: "file-alt"
 <a href="https://drive.google.com/file/d/1xC2ldAh-Z4cZJ1YIgPUPxfPYYtmIRxLA/view?usp=sharing" class="btn btn--inverse btn--x-large">NC Science Essential Standards</a>
 <a href="https://drive.google.com/file/d/1ehSRQBMQ3QAH1ylkMZbRNx3HCVWPm25F/view?usp=sharing" class="btn btn--inverse btn--x-large">Unpacked Content</a>
 <a href="https://drive.google.com/file/d/1pMoAzg_Z347bQxxr4WxORHqSXP9IjWyW/view?usp=sharing" class="btn btn--inverse btn--x-large">Assessment Examples</a>
-<a href="https://files.nc.gov/dpi/documents/files/biology_3375_released_final-2019.pdf" class="btn btn--inverse btn--x-large">Biology Released EOC </a>
+<a href="https://files.nc.gov/dpi/documents/files/biology_3375_released_final-2019.pdf" class="btn btn--inverse btn--x-large">Biology Released EOC</a>
 
 # Units
 Coming Soon


### PR DESCRIPTION
An _Additional Resources_ button has been added to the _AP Biology_ page.
![Screenshot_2021-01-04 AP Biology](https://user-images.githubusercontent.com/39242954/103603602-fb405100-4edc-11eb-8078-04eec724de38.png)
